### PR TITLE
Add more type annotations to pgtrigger.{compiler,migrations}

### DIFF
--- a/pgtrigger/core.py
+++ b/pgtrigger/core.py
@@ -536,7 +536,7 @@ def _cleanup_on_exit(cleanup):
     cleanup()
 
 
-def _ignore_func_name():
+def _ignore_func_name() -> str:
     ignore_func = "_pgtrigger_should_ignore"
     if features.schema():  # pragma: no branch
         ignore_func = f"{utils.quote(features.schema())}.{ignore_func}"


### PR DESCRIPTION
I'm considering using `django-pgtrigger` in a [project](https://salsa.debian.org/freexian-team/debusine) that's fully-typed, and in my draft branch I found that I had to add a few `type: ignore[no-untyped-call]` comments to a migration.  This should help.  Some of the annotations are of course my best-effort guesses from hunting around elsewhere in the code.