### PR TITLE
Fix use of core django management command options when using pgtrigger command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.15.4 (2025-08-16)
+
+#### Fixes
+
+  - Fix use of core Django management command options (e.g. `--skip-checks`) when using `manage.py pgtrigger` by [@wesleykendall](https://github.com/wesleykendall) in [#214](https://github.com/AmbitionEng/django-pgtrigger/pull/214).
+
 ## 4.15.3 (2025-06-12)
 
 #### Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ packages = [
 exclude = [
   "*/tests/"
 ]
-version = "4.15.3"
+version = "4.15.4"
 description = "Postgres trigger support integrated with Django models."
 authors = ["Wes Kendall"]
 classifiers = [


### PR DESCRIPTION
Fixes #213 

Now options such as `--skip-checks` can be used with `manage.py pgtrigger`. Thanks to @adamchainz blog article at https://adamj.eu/tech/2024/08/14/django-management-command-sub-commands/!